### PR TITLE
Make --help output to stdout instead of stderr.

### DIFF
--- a/src/main.cc
+++ b/src/main.cc
@@ -222,7 +222,7 @@ int program_options(Parg& pg)
 
   if (pg.get<bool>("help"))
   {
-    std::cerr << pg.help();
+    std::cout << pg.help();
 
     return 1;
   }


### PR DESCRIPTION
It makes it easier to use a pager like less or more when you want to view the help (because just stdout goes through pipes by default).